### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  # before_action :set_furima, only: [:edit, :show, :update, :destroy]
+  before_action :set_items, only: [:edit, :show]
 
   def index
 
@@ -22,14 +22,14 @@ class ItemsController < ApplicationController
     end
   end
 
-  # def show
-  # end
+  def show
+  end
 
-  # def edit
+  def edit
   #   if Record.exists?(items_id: @item.id) || current_user.id != @item.user_id
   #     redirect_to root_path      
   #   end
-  # end
+  end
 
   # def update
   #   if @item.update(item_params)
@@ -55,7 +55,7 @@ class ItemsController < ApplicationController
   def items_params
     params.require(:item).permit(:image, :item_name, :item_category_id, :item_condition_id, :item_address_id, :item_explanation, :delivery_category_id, :delivery_dey_id, :price).merge(user_id: current_user.id)
   end
-  # def set_item
-  #   @item =Item.find(params[:id])
-  # end
+  def set_items
+    @items =Item.find(params[:id])
+  end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,7 +123,7 @@
         <% @items.each do |item| %>
         <%# if message.image.attached? %>
             <li class='list'>
-              <%= link_to "#" do %>
+              <%= link_to item_path(item.id), method: :get do %>
                 <%# if @record = nil %>
                 <div class='item-img-content'>
                   <%= image_tag item.image, class: "item-img" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @items.item_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @items.image, class:"item-box-img" if @items.image.attached? %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,54 +16,52 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%="¥ #{@items.price}"%>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @items.delivery_category.name%>
       </span>
     </div>
-
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+<% if user_signed_in? %>
+  <% if user_signed_in? && current_user.id == @items.user_id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
+  <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+  <% end %>
+<% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @items.item_explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @items.user.nick_name %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @items.item_category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @items.item_condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @items.delivery_category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @items.item_address.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @items.delivery_dey.name %></td>
         </tr>
       </tbody>
     </table>
@@ -102,9 +100,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @items.item_category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>


### PR DESCRIPTION
#what
商品詳細ページの実装

#why
商品詳細ページにアクセスし、編集・削除ボタンが見えるように実装したため。
また、自分がアップロードしていない商品には購入ボタンが見えるように実装したため。


ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画https://i.gyazo.com/15abc2fca8e70ddce995d8ec95723dd3.mp4

ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画https://i.gyazo.com/f405281badd0267b4fe2fae9e7575ae7.mp4

ログアウト状態で、商品詳細ページへ遷移した動画https://i.gyazo.com/ec5562e38f871138d07eea994c48fa6e.mp4